### PR TITLE
Update ECMA-426 source reference

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -326,7 +326,7 @@
     "url": "https://tc39.es/ecma426/",
     "shortname": "ecma-426",
     "nightly": {
-      "sourcePath": "source-map.bs"
+      "sourcePath": "source-map-rev3.md"
     },
     "formerNames": [
       "sourcemap"


### PR DESCRIPTION
The TC39 committee has updated the source of ECMA-426 to `source-map-rev3.md`.
